### PR TITLE
Refactor to work with OAuth 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,52 +3,44 @@
 [Passport](http://passportjs.org/) strategy for authenticating with [HubSpot](http://www.hubspot.com/)
 using the OAuth 2.0 API.
 
-This module lets you authenticate using HubSpot in your Node.js applications.
-By plugging into Passport, HubSpot authentication can be easily and
-unobtrusively integrated into any application or framework that supports
-[Connect](http://www.senchalabs.org/connect/)-style middleware, including
-[Express](http://expressjs.com/).
+This module lets you authenticate using HubSpot in your Node.js applications. By plugging into Passport, HubSpot authentication can be easily and unobtrusively integrated into any application or framework that supports [Connect](http://www.senchalabs.org/connect/)-style middleware, including [Express](http://expressjs.com/).
 
 ## Usage
 
 #### Configure Strategy
 
-The HubSpot authentication strategy authenticates users using a HubSpot
-account and OAuth 2.0 tokens.  The strategy requires a `verify` callback, which
-accepts these credentials and calls `done` providing a user, as well as
-`options` specifying a app ID, app secret, and callback URL.
+The HubSpot authentication strategy authenticates users using a HubSpot account and OAuth 2.0 tokens.
+
+**NOTE:** Unlike normal OAuth 2.0 flows, HubSpot immediately returns an access token instead of an authorization code. Therefore, unlike other passport strategies, this strategy does not actually call the `verify` callback.
 
     passport.use(new HubSpotStrategy({
         clientID: HUBSPOT_APP_ID,
         clientSecret: HUBSPOT_APP_SECRET,
         callbackURL: "http://localhost:3000/auth/hubspot/callback"
-      }, function (accessToken, refreshToken, profile, done) {
-        User.findOrCreate({ hubspotId: profile.id }, function(err, user) {
-          return done(err, user);
-        });
-      }
+      }, function() {
+        // Useless verify callback.
+      };
     ));
 
 #### Authenticate Requests
 
-Use `passport.authenticate()`, specifying the `'hubspot'` strategy, to
-authenticate requests.
+Use `passport.authenticate()`, specifying the `'hubspot'` strategy, to authenticate requests.
 
-For example, as route middleware in an [Express](http://expressjs.com/)
-application:
+For example, as route middleware in an [Express](http://expressjs.com/) application:
 
     app.get('/auth/hubspot', passport.authenticate('hubspot'));
 
-    app.get('/auth/hubspot/callback',
-      passport.authenticate('hubspot', { failureRedirect: '/login' }),
-      function(req, res) {
-        // Successul authentication, redirect home.
+    app.get('/auth/hubspot/callback', function(req, res) {
+        // Access tokens are returned immediately as params, which you can then store somehow.
+        console.log(req.params);
+
+        // Redirect to home.
         res.redirect('/');
-      });
+    });
 
 ## Credits
 
-Created by [Brian Falk](http://github.com/brainflake)
+Based on the great work of [Brian Falk (@brainflake)](http://github.com/brainflake)
 
 Code based on passport-facebook by [Jared Hanson](http://github.com/jaredhanson)
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ The HubSpot authentication strategy authenticates users using a HubSpot account 
 
 #### Authenticate Requests
 
-Use `passport.authenticate()`, specifying the `'hubspot'` strategy, to authenticate requests.
+Use `passport.authenticate()`, specifying the `'hubspot'` strategy, to authenticate requests. You'll also need to provide a `portalId` and any scopes you'll need access to.
 
 For example, as route middleware in an [Express](http://expressjs.com/) application:
 
-    app.get('/auth/hubspot', passport.authenticate('hubspot'));
+    app.get('/auth/hubspot', passport.authenticate('hubspot', {
+        portalId: 62515,
+        scope: ['offline', 'contacts-ro', 'contacts-rw']
+      })
+    );
 
     app.get('/auth/hubspot/callback', function(req, res) {
         // Access tokens are returned immediately as params, which you can then store somehow.

--- a/lib/passport-hubspot/index.js
+++ b/lib/passport-hubspot/index.js
@@ -1,5 +1,15 @@
+/**
+ * Module dependencies.
+ */
 var Strategy = require('./strategy');
 
-require('pkginfo')(module, 'version');
 
+/**
+ * Expose `Strategy` directly from package.
+ */
+exports = module.exports = Strategy;
+
+/**
+ * Export constructors.
+ */
 exports.Strategy = Strategy;

--- a/lib/passport-hubspot/strategy.js
+++ b/lib/passport-hubspot/strategy.js
@@ -13,7 +13,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://app.hubspot.com/auth/authenticate/';
   options.tokenURL = options.tokenURL || 'https://app.hubspot.com/auth/token';
-  options.scopeSeparator = options.scopeSeparator || '+';
+  options.scopeSeparator = options.scopeSeparator || ' ';
   options.skipUserProfile = true
 
   OAuth2Strategy.call(this, options, verify);

--- a/lib/passport-hubspot/strategy.js
+++ b/lib/passport-hubspot/strategy.js
@@ -1,36 +1,9 @@
-var OAuth2Strategy = require('passport-oauth').OAuth2Strategy
-  , InternalOAuthError = require('passport-oauth').InternalOAuthError
-  , url = require('url')
-  , util = require('util');
+var OAuth2Strategy = require('passport-oauth2'),
+    InternalOAuthError = require('passport-oauth2').InternalOAuthError,
+    util = require('util');
 
 /**
  * `Strategy` constructor.
- *
- * HubSpot uses the OAuth 2.0 protocol for authentication.
- *
- * Applications using this must supply a callback to verify the credentials which
- * accepts an `accessToken`, `refreshToken`, and a `profile`. After verifying the
- * credentials it should call `done` with the user object and any error that may
- * have occured as the first parameter.
- *
- * Options:
- *   - `clientID`	your HubSpot application's App ID
- *   - `clientSecret`	your HubSpot application's App Secret
- *   - `callbackURL`	URL to which HubSpot will redirect the user after granting authorization
- *
- * Examples:
- *
- *     passport.use(new HubSpotStrategy({
- *         clientID: 'HUBSPOT_APP_ID',
- *         clientSecret: 'SECRET_SAUCE',
- *         callbackURL: 'https://www.example.net/auth/hubspot/callback'
- *       },
- *       function(accessToken, refreshToken, profile, done) {
- *         User.findOrCreate(..., function (err, user) {
- *           done(err, user);
- *         });
- *       }
- *     ));
  *
  * @param {Object} options
  * @param {Function} verify
@@ -40,15 +13,42 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://app.hubspot.com/auth/authenticate/';
   options.tokenURL = options.tokenURL || 'https://app.hubspot.com/auth/token';
+  options.scopeSeparator = options.scopeSeparator || '+';
+  options.skipUserProfile = true
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'hubspot';
-  this._oauth2._useAuthorizationHeaderForGET = true;
-  this._oauth2._skipUserProfile = true;
 }
 
+/**
+ * Inherit from `OAuth2Strategy`.
+ */
 util.inherits(Strategy, OAuth2Strategy);
 
+
+/**
+ * Authenticate request by delegating to a service provider using OAuth 2.0.
+ *
+ * @param {Object} req
+ * @api public
+ */
+Strategy.prototype.authenticate = function(req, options) {
+  options = options || {};
+
+  if (req.query && req.query.error) {
+    // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
+    //       query parameters, and should be propagated to the application.
+    return this.fail();
+  }
+
+  OAuth2Strategy.prototype.authenticate.call(this, req, options);
+}
+
+/**
+ * Append additional parameters to the request.
+ * @param  {Object} options
+ * @api protected
+ */
 Strategy.prototype.authorizationParams = function(options) {
   var params = {};
 
@@ -57,151 +57,6 @@ Strategy.prototype.authorizationParams = function(options) {
   }
 
   return params;
-}
-
-/**
- * Reconstructs the original URL of the request.
- *
- * This function builds a URL that corresponds the original URL requested by the
- * client, including the protocol (http or https) and host.
- *
- * If the request passed through any proxies that terminate SSL, the
- * `X-Forwarded-Proto` header is used to detect if the request was encrypted to
- * the proxy.
- *
- * @return {String}
- * @api private
- */
-function originalURL (req) {
-  var headers = req.headers
-    , protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] == 'https')
-               ? 'https'
-               : 'http'
-    , host = headers.host
-    , path = req.url || '';
-  return protocol + '://' + host + path;
-}
-
-/**
- * Authenticate request by delegating to a service provider using OAuth 2.0.
- *
- * @param {Object} req
- * @api protected
- */
-Strategy.prototype.authenticate = function(req, options) {
-  options = options || {};
-  var self = this;
-
-  if (req.query && req.query.error) {
-    // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
-    //       query parameters, and should be propagated to the application.
-    return this.fail();
-  }
-
-  var callbackURL = options.callbackURL || this._callbackURL;
-  if (callbackURL) {
-    var parsed = url.parse(callbackURL);
-    if (!parsed.protocol) {
-      // The callback URL is relative, resolve a fully qualified URL from the
-      // URL of the originating request.
-      callbackURL = url.resolve(originalURL(req), callbackURL);
-    }
-  }
-
-  function loadProfile (accessToken, refreshToken) {
-    self._loadUserProfile(accessToken, function(err, profile) {
-      if (err) { return self.error(err); }
-
-      function verified(err, user, info) {
-        if (err) { return self.error(err); }
-        if (!user) { return self.fail(info); }
-        self.success(user, info);
-      }
-
-      if (self._passReqToCallback) {
-        var arity = self._verify.length;
-        if (arity == 6) {
-          self._verify(req, accessToken, refreshToken, params, profile, verified);
-        } else { // arity == 5
-          self._verify(req, accessToken, refreshToken, profile, verified);
-        }
-      } else {
-        var arity = self._verify.length;
-        if (arity == 5) {
-          self._verify(accessToken, refreshToken, params, profile, verified);
-        } else { // arity == 4
-          self._verify(accessToken, refreshToken, profile, verified);
-        }
-      }
-    });
-  }
-
-  if (req.query && req.query.access_token && req.query.refresh_token) {
-    return loadProfile(req.query.access_token, req.query.refresh_token);
-  }
-
-  if (req.query && req.query.code) {
-    var code = req.query.code;
-
-    // NOTE: The module oauth (0.9.5), which is a dependency, automatically adds
-    //       a 'type=web_server' parameter to the percent-encoded data sent in
-    //       the body of the access token request.  This appears to be an
-    //       artifact from an earlier draft of OAuth 2.0 (draft 22, as of the
-    //       time of this writing).  This parameter is not necessary, but its
-    //       presence does not appear to cause any issues.
-    this._oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL },
-      function(err, accessToken, refreshToken, params) {
-        if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
-
-        loadProfile(accessToken, refreshToken);
-        /* self._loadUserProfile(accessToken, function(err, profile) {
-          if (err) { return self.error(err); };
-
-          function verified(err, user, info) {
-            if (err) { return self.error(err); }
-            if (!user) { return self.fail(info); }
-            self.success(user, info);
-          }
-
-          if (self._passReqToCallback) {
-            var arity = self._verify.length;
-            if (arity == 6) {
-              self._verify(req, accessToken, refreshToken, params, profile, verified);
-            } else { // arity == 5
-              self._verify(req, accessToken, refreshToken, profile, verified);
-            }
-          } else {
-            var arity = self._verify.length;
-            if (arity == 5) {
-              self._verify(accessToken, refreshToken, params, profile, verified);
-            } else { // arity == 4
-              self._verify(accessToken, refreshToken, profile, verified);
-            }
-          }
-        }); */
-      }
-    );
-  } else {
-    // NOTE: The module oauth (0.9.5), which is a dependency, automatically adds
-    //       a 'type=web_server' parameter to the query portion of the URL.
-    //       This appears to be an artifact from an earlier draft of OAuth 2.0
-    //       (draft 22, as of the time of this writing).  This parameter is not
-    //       necessary, but its presence does not appear to cause any issues.
-
-    var params = this.authorizationParams(options);
-    params['response_type'] = 'code';
-    params['redirect_uri'] = callbackURL;
-    var scope = options.scope || this._scope;
-    if (scope) {
-      if (Array.isArray(scope)) { scope = scope.join(this._scopeSeparator); }
-      params.scope = scope;
-    }
-    var state = options.state;
-    if (state) { params.state = state; }
-
-    var location = this._oauth2.getAuthorizeUrl(params);
-    this.redirect(location);
-  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,27 +1,24 @@
 {
   "name": "passport-hubspot",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Hubspot authentication strategy for Passport.",
-  "keywords": ["hubspot", "passport", "auth", "authentication"],
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/brainflake/passport-hubspot.git"
-  },
+  "keywords": [
+    "hubspot",
+    "passport",
+    "auth",
+    "authentication"
+  ],
+  "repository": "",
   "main": "lib/passport-hubspot/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": "",
-  "author": {
-    "name": "Brian Falk",
-    "email": "falk@logicparty.org"
-  },
-  "license": "BSD",
+  "author": "Jonathan Kim (http://appcues.com)",
+  "contributors": [
+    "Brian Falk <falk@logicparty.org> (https://github.com/brainfalk)"
+  ],
+  "license": "MIT",
   "dependencies": {
-    "passport-oauth": "~0.1.15",
-    "pkginfo": "~0.3.0"
-  },
-  "devDependencies": {
-    "vows": "0.7.0"
+    "passport-oauth2": "^1.1.2"
   }
 }


### PR DESCRIPTION
The previous version of this didn't actually seem to work, and it looked like a lot of the code has actually been implemented in Jared's `passport-oauth2` library. It also didn't seem to honor any of the weirdness about HubSpot's oauth implementation, like the fact that they don't have an authorization code step or utilize the verify callback.

I put myself as the author since it's such a big refactor, but I really don't care much. If you wanna own this repo going forward, I'd be happy to change it back :fried_shrimp: 
