### PR TITLE
adding deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Passport-Hubspot
 
+# This repo is being depcrecated in favor of [passport-hubspot-oauth2](https://www.npmjs.com/package/passport-hubspot-oauth2) which is being actively maintained and is current with HubSpot's OAuth 2.0 implementation.
+
 [Passport](http://passportjs.org/) strategy for authenticating with [HubSpot](http://www.hubspot.com/)
 using the OAuth 2.0 API.
 


### PR DESCRIPTION
I don't know how the listing [here](http://www.passportjs.org/packages/passport-hubspot/) will work but I'm guessing it's reading of the README file. Not sure if you will need to republish this anywhere after a merge. 